### PR TITLE
Cambiar display de datos de las restricciones cuando se tienen valores por defecto

### DIFF
--- a/src/components/restriction.vue
+++ b/src/components/restriction.vue
@@ -38,7 +38,7 @@ export default {
   props: {
     id: String,
     valueName: String,
-    defaultValue: Number,
+    defaultValue: [Number, Boolean],
     headerText: String,
     example: String,
     tipText: String,

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,18 @@
-import { createApp} from "vue";
+import { createApp } from "vue";
 import App from "./App.vue";
 import "@/assets/css/tailwind.css";
 import router from "./router";
 
+// 1. Assign app to a variable
+let app = createApp(App)
 
-createApp(App)
-  .use(router)
-  .mount("#app");
+// 2. Assign the global variable before mounting
+app.config.globalProperties.apiLink = "http://127.0.0.1:8000";
+// app.config.globalProperties.apiLink = "https://8sdgtp.deta.dev/";
+
+// 3. Use router and mount app
+app.use(router).mount('#app');
+
+
+
 

--- a/src/views/assigner.vue
+++ b/src/views/assigner.vue
@@ -146,7 +146,7 @@ export default {
             p: this.names.length,
           };
           const response = await axios.post(
-            "https://8sdgtp.deta.dev/get_restriction_options",
+            this.apiLink + "/get_restriction_options",
             post
           );
 
@@ -183,14 +183,14 @@ export default {
             days: this.days,
             costs: costs,
             min_assign_task: 1,
-            max_assign_task: 1000,
-            max_total_assign: 1000,
+            max_assign_task: false,
+            max_total_assign: false,
             min_total_assign: 1,
           };
 
           // Esto debería ser una función. Llamémosla function2()
           const response = await axios.post(
-            "https://8sdgtp.deta.dev/resolve/",
+            this.apiLink + "/resolve/",
             problemParams
           );
           if (response.data.status == "Optimal") {

--- a/src/views/costAssigner.vue
+++ b/src/views/costAssigner.vue
@@ -106,7 +106,7 @@ export default {
     async checkCosts() {
       let post = { costs: this.costs };
       const response = await axios.post(
-        "https://8sdgtp.deta.dev/checkCosts/",
+        this.apiLink + "/checkCosts/",
         post
       );
       this.canContinue = response.data;
@@ -122,7 +122,7 @@ export default {
             p: this.names.length,
           };
           const response = await axios.post(
-            "https://8sdgtp.deta.dev/get_restriction_options",
+            this.apiLink + "/get_restriction_options",
             post
           );
 
@@ -146,14 +146,14 @@ export default {
             days: this.days,
             costs: this.costs,
             min_assign_task: 1,
-            max_assign_task: 10000,
-            max_total_assign: 10000,
+            max_assign_task: false,
+            max_total_assign: false,
             min_total_assign: 1,
           };
 
           // Esto debería ser una función. Llamémosla function2()
           const response = await axios.post(
-            "https://8sdgtp.deta.dev/resolve/",
+            this.apiLink + "/resolve/",
             problemParams
           );
           if (response.data.status == "Optimal") {
@@ -175,7 +175,7 @@ export default {
   async created() {
     let post = { tasks: this.tasks };
     const response = await axios.post(
-      "https://8sdgtp.deta.dev/getOptions/",
+      this.apiLink + "/getOptions/",
       post
     );
     this.options = response.data;

--- a/src/views/optimizer.vue
+++ b/src/views/optimizer.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="w-full flex flex-col m-5 mb-24 items-center mx-auto space-y-7 md:space-y-10">
-    <h1 class="px-3 md: px-0 pt-10 text-center text-2xl md:text-3xl font-bold text-blue-500">
+    <h1 class="px-3 md:px-0 pt-10 text-center text-2xl md:text-3xl font-bold text-blue-500">
       Asignación de tareas por día
     </h1>
     <div
@@ -23,7 +23,7 @@
         </li>
       </ul>
     </div>
-    <div class="px-10 md:p-0 md:w-1/4 text-center" v-if="problemSettings.max_assign_task > 500">
+    <div class="px-10 md:p-0 md:w-1/4 text-center">
       <h1 class="font-semibold">Restricciones de justicia del problema:</h1>
       <ul class="text-left py-5 list-disc">
         <li>
@@ -32,7 +32,7 @@
           <span v-if="problemSettings.min_assign_task > 1">veces</span
           ><span v-else>vez</span> cada tarea en la semana.
         </li>
-        <li>
+        <li v-if="problemSettings.max_assign_task">
           Cada persona puede realizar a lo más
           {{ problemSettings.max_assign_task }}
           <span v-if="problemSettings.max_assign_task > 1">veces</span
@@ -46,7 +46,7 @@
           ><span v-else>tarea</span> cada semana.
         </li>
         -->
-        <li>
+        <li v-if="problemSettings.max_total_assign">
           Cada persona debe realizar a lo más
           {{ problemSettings.max_total_assign }}
           <span v-if="problemSettings.max_total_assign > 1">tareas</span
@@ -82,7 +82,7 @@ export default {
         p: this.problemSettings.names.length,
       };
       const response = await axios.post(
-        "https://8sdgtp.deta.dev/get_restriction_options",
+        this.apiLink + "/get_restriction_options",
         post
       );
 

--- a/src/views/restrictionAssigner.vue
+++ b/src/views/restrictionAssigner.vue
@@ -91,7 +91,7 @@ export default {
 
       // Esto debería ser una función. Llamémosla function2()
       const response = await axios.post(
-        "https://8sdgtp.deta.dev/resolve/",
+        this.apiLink + "/resolve/",
         problemParams
       );
       if (response.data.status == "Optimal") {
@@ -116,8 +116,8 @@ export default {
       cantSolve: false,
       selectedOptions: {
         min_assign_task: 1,
-        max_assign_task: 10000,
-        max_total_assign: 10000,
+        max_assign_task: false,
+        max_total_assign: false,
         min_total_assign: 1,
       },
       restrictionsList: [
@@ -137,7 +137,7 @@ export default {
         {
           id: "2",
           valueName: "max_assign_task",
-          defaultValue: 1000,
+          defaultValue: false,
           headerText:
             "Ingresa el número máximo de asignaciones que puede tener una persona en una tarea durante la semana.",
           example:
@@ -150,7 +150,7 @@ export default {
         {
           id: "3",
           valueName: "max_total_assign",
-          defaultValue: 1000,
+          defaultValue: false,
           headerText:
             "Ingresa el número máximo de asignaciones totales  que puede tener una persona durante una semana.",
           example:


### PR DESCRIPTION
Hice cambios tanto en el frontend como el backend, asi que este pull request está asociado a [este otro pull request](https://github.com/emeiese/task-assignation-backend/pull/2) del backend

- Cambié el path del `apiLink` porque de otra forma no podía ver lo cambios que tuve que hacer en el backend para hacer esta tarea. Esto se podría mejorar pero no tengo claro cómo.
- Permití que el valor por defecto (si es que el usuario no quiere poner costos o restricciones) sea `false` y que cuando el backend reciba esto, pueda manejarlo. 